### PR TITLE
Added AutoModerator to the config permission tooltip

### DIFF
--- a/r2/r2/lib/permissions.py
+++ b/r2/r2/lib/permissions.py
@@ -78,7 +78,7 @@ class ModeratorPermissionSet(PermissionSet):
         ),
         config=dict(
             title=N_('config'),
-            description=N_('edit settings, sidebar, css, and images'),
+            description=N_('edit settings, sidebar, css, images, and AutoModerator'),
         ),
         flair=dict(
             title=N_('flair'),


### PR DESCRIPTION
The config permission now has the ability to manage AutoModerator, so the tooltip should reflect this.